### PR TITLE
Updated gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ composer.lock
 .DS_Store
 
 public/wp
-vendor
+/vendor/
 !public/wp-content/plugins
 public/wp-config.php
 public/wp-content/uploads


### PR DESCRIPTION
### Target #45
### Description
* Rewrote the rules for vendor folder in gitignore.
  *  Now, only the vendor folder at the root directory will be ignored.